### PR TITLE
Incorrect type of parameter (`addsiren`).

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1859,7 +1859,7 @@ stock WC_DestroyVehicle(vehicleid)
 	return 0;
 }
 
-stock WC_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, addsiren = 0)
+stock WC_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay, bool:addsiren = false)
 {
 	new id = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay, addsiren);
 


### PR DESCRIPTION
According to `samp-stdlib`, parameter `addsiren` in `CreateVehicle` should be `bool` not `int`. 
(when using latest pawncc from pawn-lang/compiler it throws a warning regarding that).