### PR TITLE
Use correct Pawn.RakNet version for OMP

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -2,5 +2,5 @@
   "user": "oscar-broman",
   "repo": "samp-weapon-config",
   "contributors": ["oscar-broman"],
-  "dependencies": ["sampctl/samp-stdlib", "katursis/Pawn.RakNet:1.5.1"]
+  "dependencies": ["sampctl/samp-stdlib", "katursis/Pawn.RakNet@omp:1.5.1"]
 }


### PR DESCRIPTION
The default branch in Pawn.Raknet is still used for SA:MP.
Without specifying the omp branch, sampctl will try to use the samp version which will result in the component not being loaded. 